### PR TITLE
2019 01 06/dev

### DIFF
--- a/ac.scm
+++ b/ac.scm
@@ -1490,11 +1490,17 @@
 
 (xdef bcrypt ; (passwd salt) see BSD manual crypt(3)
   (let* ((p (malloc 'atomic 256)))
-    (lambda (pwd salt)
+    (lambda (pwd salt . failed)
       (atomic-invoke (lambda ()
         (memset p 0 256)
         (bcrypt pwd salt p)
-        (cast p _pointer _string))))))
+        (let ((x (cast p _pointer _string)))
+          (if (or (<= (string-length x) 0)
+                  (not (eqv? (string-ref x 0) #\$)))
+              (if (pair? failed)
+                  (car failed)
+                  (err "bcrypt failed; use a salt like (+ \"$2a$10$\" (rand-string 22))"))
+              x)))))))
 
 (xdef system-type system-type)
 

--- a/ac.scm
+++ b/ac.scm
@@ -1145,7 +1145,10 @@
           ((eqv? form ':a) eof)
           (#t `(ac-prompt-eval ',form)))))
 
+(define reload #f)
+
 (define (ac-prompt-eval expr)
+  (when reload (arc-eval '(reload)))
   (let ((val (arc-eval expr)))
     (namespace-set-variable-value! (ac-global-name 'that) val)
     (namespace-set-variable-value! (ac-global-name 'thatexpr) expr)
@@ -1413,6 +1416,7 @@
 (xdef declare (lambda (key val)
                 (let ((flag (not (ar-false? val))))
                   (case key
+                    ((reload)         (set! reload         flag))
                     ((atstrings)      (set! atstrings      flag))
                     ((direct-calls)   (set! direct-calls   flag))
                     ((explicit-flush) (set! explicit-flush flag)))

--- a/app.arc
+++ b/app.arc
@@ -697,7 +697,7 @@
   (+ "'" (multisubst (list (list "'" "'\"'\"'")) str) "'"))
 
 (def shell (cmd . args)
-  (tostring:system (+ (string cmd) " " (string:intersperse #\space (map shellquote:string args)))))
+  (tostring:system (+ (string cmd) " " (string:intersperse #\space (map shellquote:string (rem nil args))))))
 
 (def GET (url)
   (shell "curl" "-fsSL" (clean-url url)))

--- a/arc.arc
+++ b/arc.arc
@@ -1732,6 +1732,13 @@
 (def macos? ()
   (is (system-type) 'macosx))
 
+(def yesno ((o question) (o default))
+  (if question (prn question))
+  (pr "Continue? " (if default "[Y/n]" "[y/N]") " ")
+  (aand (read (stdin) eof)
+        (if (is it eof)
+            default
+            (in it 'y 'yes 'Y 'YES))))
 
 ; any logical reason I can't say (push x (if foo y z)) ?
 ;   eval would have to always ret 2 things, the val and where it came from

--- a/arc.arc
+++ b/arc.arc
@@ -724,6 +724,8 @@
        ,@(map [do `(aif ,_ (,ga it))]
               body))))
 
+(def eof () nil)
+
 ; Repeatedly evaluates its body till it returns nil, then returns vals.
 
 (mac drain (expr (o eof nil))
@@ -848,13 +850,14 @@
 
 (def readfile1 (name) (w/infile s name (read s)))
 
-(def readall (src (o eof nil))
-  ((afn (i)
+(def readall (src (o n))
+  ((afn (i n)
     (let x (read i eof)
-      (if (is x eof)
+      (if (or (is x eof) (and n (<= n 0)))
           nil
-          (cons x (self i)))))
-   (if (isa src 'string) (instring src) src)))
+          (cons x (self i (- n 1))))))
+   (if (isa src 'string) (instring src) src)
+   n))
 
 (def allchars (str)
   (tostring (whiler c (readc str nil) no

--- a/arc.arc
+++ b/arc.arc
@@ -1473,7 +1473,7 @@
        (pr ,@(parse-format str))))
 )
 
-(^ loaded-files* (list "arc.arc"))
+(^ loaded-files* (list "arc.arc" "libs.arc"))
 (^ loaded-file-times* (obj "arc.arc" (modtime "arc.arc")))
 
 (def loaded-files () (rev loaded-files*))

--- a/git.arc
+++ b/git.arc
@@ -1,0 +1,59 @@
+(def git-hash-id (hash)
+  (cut hash 0 7))
+
+(def git--read-branch (line)
+  (if (headmatch "  " line)
+      (git--read-branch (+ "- " line))
+      (aand (readall line 3)
+            (if (is (last it) '->) (readall line 4) it)
+            (cons (is (car it) '*) (cdr it)))))
+
+(def git-branches ()
+  (map git--read-branch (lines:shell 'git 'branch '-rv '--all)))
+
+(def git-branch-refs ((o ref))
+  (aand (pair:tokens:shell 'git 'show-ref)
+        (map (fn ((hash name))
+               (list name (git-hash-id hash)))
+             it)))
+
+(def git-branch-current ((o name) (o commit) (o short?))
+  (trim:shell 'git 'symbolic-ref (if short? '--short) name (or commit "HEAD")))
+
+(def git-branch-commit ((o ref (git-branch-current)))
+  (alref (git-branch-refs) ref))
+
+(def git-log ((o commit "HEAD"))
+  (shell 'git 'log '-1 commit))
+
+(def git-current-branch-name ()
+  (aand (find (fn ((current? . args)) current?) (git-branches))
+        (cadr it)))
+
+(def git-clean ((o silent))
+  (when (or silent
+            (yesno "Warning: about to delete untracked files/folders and uncommitted changes"))
+    (shell 'git 'clean '-f '-d '-e ".*")))
+
+; https://stackoverflow.com/questions/2358643/git-discard-all-changes-on-a-diverged-local-branch
+(def git-reset-to-origin ((o silent)
+                          (o branch (git-current-branch-name))
+                          (o remote 'origin))
+  (let name (string remote "/" branch)
+    (when (or silent
+              (yesno (string "Warning: about to reset to " name)))
+      (shell 'git 'stash)
+      (shell 'git 'reset '--hard name)
+      (git-clean silent)
+      (unless silent
+        (git-print-status)))))
+
+(def git-pull ()
+  (aand (tostring:system "rm -f .git/index.lock && git pull >/dev/null && printf 1 || git merge --abort")
+        (~headmatch "1" it)))
+
+(def git-print-status ()
+  (pr (shell 'git 'status))
+  nil)
+
+

--- a/libs.arc
+++ b/libs.arc
@@ -2,6 +2,7 @@
             "pprint.arc"
             "code.arc"
             "html.arc"
+            "git.arc"
             "srv.arc"
             "app.arc"
             "prompt.arc"))

--- a/srv.arc
+++ b/srv.arc
@@ -629,7 +629,7 @@ Connection: close"))
 (def git-pull-reload ()
   (when (errsafe:git-pull)
     (when (readenv "NUKE")
-      (errsafe:git-reset-to-origin))
+      (errsafe:git-reset-to-origin t))
     (++ git-pull-count*))
   (errsafe:reload))
 

--- a/srv.arc
+++ b/srv.arc
@@ -627,7 +627,10 @@ Connection: close"))
    git-pull-count* 0)
 
 (def git-pull-reload ()
-  (if (errsafe:git-pull) (++ git-pull-count*))
+  (when (errsafe:git-pull)
+    (when (readenv "NUKE")
+      (errsafe:git-reset-to-origin))
+    (++ git-pull-count*))
   (errsafe:reload))
 
 (def git-pull-stats ()

--- a/srv.arc
+++ b/srv.arc
@@ -626,10 +626,6 @@ Connection: close"))
 (^ git-pull-time* (readenv "PULL" nil)
    git-pull-count* 0)
 
-(def git-pull ()
-  (aand (tostring:system "git pull>/dev/null && printf 1 || git merge --abort")
-        (~headmatch "1" it)))
-
 (def git-pull-reload ()
   (if (errsafe:git-pull) (++ git-pull-count*))
   (errsafe:reload))

--- a/strings.arc
+++ b/strings.arc
@@ -123,10 +123,11 @@
     nil))
 
 (def headmatch (pat seq (o start 0))
-  (let p (len pat) 
-    ((afn (i)      
-       (or (is i p) 
-           (and (is (pat i) (seq (+ i start)))
+  (with (p (len pat) s (len seq))
+    ((afn (i)
+       (or (is i p)
+           (and (< (+ i start) s)
+                (is (pat i) (seq (+ i start)))
                 (self (+ i 1)))))
      0)))
 


### PR DESCRIPTION
- Fix HEADMATCH when pat is longer than seq
- Can now declare 'reload t for repl autoreload
- Remove nil arguments from SHELL
- READALL now handles reading "foo nil bar"
- READALL now accepts a max read count
- Define YESNO
- Define git utilities in git.arc
- When NUKE=1 is set, hard reset to origin on `(git-pull-reload)` (e.g. when `PULL=10` is set)
- Upgrade password strength to bcrypt